### PR TITLE
fix: Exclude construct ID that are not in PascalCase in CDK's L2 Constructs

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -5,6 +5,10 @@
       "type": "build"
     },
     {
+      "name": "@aws-cdk/lambda-layer-kubectl-v24",
+      "type": "build"
+    },
+    {
       "name": "@stylistic/eslint-plugin",
       "version": "^2",
       "type": "build"

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -274,13 +274,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@aws-cdk/assert,@types/jest,@types/node,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,projen,ts-jest,ts-node,typescript"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@aws-cdk/assert,@aws-cdk/lambda-layer-kubectl-v24,@types/jest,@types/node,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,projen,ts-jest,ts-node,typescript"
         },
         {
           "exec": "npm install"
         },
         {
-          "exec": "npm update @aws-cdk/assert @stylistic/eslint-plugin @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser commit-and-tag-version eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit jsii-diff jsii-docgen jsii-pacmak jsii-rosetta jsii projen ts-jest ts-node typescript aws-cdk-lib constructs"
+          "exec": "npm update @aws-cdk/assert @aws-cdk/lambda-layer-kubectl-v24 @stylistic/eslint-plugin @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser commit-and-tag-version eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit jsii-diff jsii-docgen jsii-pacmak jsii-rosetta jsii projen ts-jest ts-node typescript aws-cdk-lib constructs"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -13,7 +13,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   packageManager: NodePackageManager.NPM,
   license: 'MIT',
 
-  devDeps: ['@aws-cdk/assert'],
+  devDeps: ['@aws-cdk/assert', '@aws-cdk/lambda-layer-kubectl-v24'],
 
   gitignore: ['.vscode', '**/.DS_Store'],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@aws-cdk/assert": "^2.68.0",
+        "@aws-cdk/lambda-layer-kubectl-v24": "^2.0.242",
         "@stylistic/eslint-plugin": "^2",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.10.5",
@@ -118,6 +119,17 @@
       },
       "engines": {
         "node": ">= 14.15.0"
+      }
+    },
+    "node_modules/@aws-cdk/lambda-layer-kubectl-v24": {
+      "version": "2.0.242",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/lambda-layer-kubectl-v24/-/lambda-layer-kubectl-v24-2.0.242.tgz",
+      "integrity": "sha512-7/wIOo685tmrEe4hh6zqDELhBZh5OQGf3Hd2FU2Vnwy2ZubW8qTmEw5gqJCsCrGKeYDoa1BcVhDRZ/nzjkaqyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.28.0",
+        "constructs": "^10.0.5"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@aws-cdk/assert": "^2.68.0",
+    "@aws-cdk/lambda-layer-kubectl-v24": "^2.0.242",
     "@stylistic/eslint-plugin": "^2",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.5",

--- a/src/excluded-resource-types.ts
+++ b/src/excluded-resource-types.ts
@@ -27,8 +27,6 @@ export const EXCLUDED_PREFIX_NAMES = [
   'waiter-state-machine',
 ];
 
-// 明日は特定のリソースが、特定の項目名の場合除外する設定を追加
-
 interface RESOURCE_AND_NAME_PATTERN {
   resourceType: string;
   namePattern: string;

--- a/src/excluded-resource-types.ts
+++ b/src/excluded-resource-types.ts
@@ -13,7 +13,7 @@ export const EXCLUDED_RESOURCE_TYPES = new Set([
   'AWS::CloudFormation::Stack',
   'AWS::CloudFront::Distribution',
   'AWS::SNS::Subscription',
-  // ↓ No Test Added
+  // No Test Added. Because since the following resources are not available in the current version of CDK
   'AWS::ApiGatewayV2::Integration',
   'AWS::ApiGatewayV2::Route',
   'AWS::Lambda::Permission',

--- a/src/excluded-resource-types.ts
+++ b/src/excluded-resource-types.ts
@@ -1,0 +1,48 @@
+// Exclude AWS resources that contain non-PascalCase paths.
+export const EXCLUDED_RESOURCE_TYPES = new Set([
+  'AWS::ApiGateway::Stage',
+  'AWS::ApiGateway::Method',
+  'AWS::ApiGateway::Resource',
+  'AWS::Lambda::EventSourceMapping',
+  'AWS::EC2::EIP',
+  'AWS::EC2::InternetGateway',
+  'AWS::EC2::VPCGatewayAttachment',
+  'AWS::AutoScaling::AutoScalingGroup',
+  'AWS::EC2::SecurityGroupIngress',
+  'AWS::EC2::SecurityGroupEgress',
+  'AWS::CloudFormation::Stack',
+  'AWS::CloudFront::Distribution',
+  'AWS::SNS::Subscription',
+  // ↓ No Test Added
+  'AWS::ApiGatewayV2::Integration',
+  'AWS::ApiGatewayV2::Route',
+  'AWS::Lambda::Permission',
+  'AWS::AppConfig::Deployment',
+]);
+
+export const EXCLUDED_PREFIX_NAMES = [
+  'Custom::',
+  // KubectlV24Layer Only
+  'framework-',
+  'waiter-state-machine',
+];
+
+// 明日は特定のリソースが、特定の項目名の場合除外する設定を追加
+
+interface RESOURCE_AND_NAME_PATTERN {
+  resourceType: string;
+  namePattern: string;
+}
+
+export const EXCLUDED_RESOURCE_AND_NAME_PATTERNS: RESOURCE_AND_NAME_PATTERN[] = [
+  // ecs-patterns
+  {
+    resourceType: 'AWS::ElasticLoadBalancingV2::LoadBalancer',
+    namePattern: 'LB',
+  },
+  // cognito
+  {
+    resourceType: 'AWS::IAM::Role',
+    namePattern: 'smsRole',
+  },
+];

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export class CdkMentor implements cdk.IAspect {
           !EXCLUDED_RESOURCE_TYPES.has(node.cfnResourceType) &&
           !EXCLUDED_PREFIX_NAMES.some((prefix) => constructId.startsWith(prefix)) &&
           !EXCLUDED_RESOURCE_AND_NAME_PATTERNS.some(
-            (rule) => node.cfnResourceType === rule.resourceType && constructId.includes(rule.namePattern)
+            (rule) => node.cfnResourceType === rule.resourceType && constructId.includes(rule.namePattern),
           )
         ) {
           cdk.Annotations.of(node).addError(`[ERR:001]: Construct ID "${constructId}"should be defined in PascalCase.`);
@@ -40,7 +40,7 @@ export class CdkMentor implements cdk.IAspect {
         // If it is not a CrossStack reference, immediately WARN
         if (stackDependencies && Object.keys(stackDependencies).length === 0) {
           cdk.Annotations.of(node).addWarning(
-            `[WARN:001]: Construct ID names should NOT include the word "Stack" "${constructId}". The Stack concept from CDK is reflected in the resource names.`
+            `[WARN:001]: Construct ID names should NOT include the word "Stack" "${constructId}". The Stack concept from CDK is reflected in the resource names.`,
           );
         }
         // Exclude if it is a CrossStack reference and the referenced stack name is included.
@@ -51,14 +51,14 @@ export class CdkMentor implements cdk.IAspect {
           !constructId.includes(this.getJsonRootKey(stackDependencies))
         ) {
           cdk.Annotations.of(node).addWarning(
-            `[WARN:001]: Construct ID names should NOT include the word "Stack" "${constructId}". The Stack concept from CDK is reflected in the resource names.`
+            `[WARN:001]: Construct ID names should NOT include the word "Stack" "${constructId}". The Stack concept from CDK is reflected in the resource names.`,
           );
         }
       }
 
       if (constructId && constructId.includes('Construct')) {
         cdk.Annotations.of(node).addWarning(
-          `[WARN:002]: Construct ID names should NOT include the word "Construct" "${constructId}". The Construct concept from CDK is reflected in the resource names.`
+          `[WARN:002]: Construct ID names should NOT include the word "Construct" "${constructId}". The Construct concept from CDK is reflected in the resource names.`,
         );
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,6 @@ export class CdkMentor implements cdk.IAspect {
             (rule) => node.cfnResourceType === rule.resourceType && constructId.includes(rule.namePattern)
           )
         ) {
-          console.log();
           cdk.Annotations.of(node).addError(`[ERR:001]: Construct ID "${constructId}"should be defined in PascalCase.`);
         }
       }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,10 +2,29 @@ import { SynthUtils } from '@aws-cdk/assert';
 
 import * as cdk from 'aws-cdk-lib';
 
-// MEMO: We'll use SNS to test, as it requires actual resources in the Cfn template.
-import { Stack, aws_sns as sns, aws_sqs as sqs } from 'aws-cdk-lib';
-import { SqsSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
+import { Stack } from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
 import { Construct } from 'constructs';
+import * as sns from 'aws-cdk-lib/aws-sns';
+import * as sqs from 'aws-cdk-lib/aws-sqs';
+import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import * as autoscaling from 'aws-cdk-lib/aws-autoscaling';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as ecsPatterns from 'aws-cdk-lib/aws-ecs-patterns';
+import * as eks from 'aws-cdk-lib/aws-eks';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as route53 from 'aws-cdk-lib/aws-route53';
+import * as route53Patterns from 'aws-cdk-lib/aws-route53-patterns';
+import * as snsSubscriptions from 'aws-cdk-lib/aws-sns-subscriptions';
+import * as subs from 'aws-cdk-lib/aws-sns-subscriptions';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import { KubectlV24Layer } from '@aws-cdk/lambda-layer-kubectl-v24';
+
+// MEMO: The following modules are not available in the current CDK version
+// import * as appconfig from '@aws-cdk/aws-appconfig';
+// import * as apigatewayv2 rom 'aws-cdk-lib/aws-apigatewayv2';
+
 import { CdkMentor } from '../src/index';
 
 let stack: Stack;
@@ -25,7 +44,7 @@ describe('PascalCase Construct ID Check', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      }),
+      })
     );
   });
   describe.each`
@@ -49,9 +68,457 @@ describe('PascalCase Construct ID Check', () => {
           entry: expect.objectContaining({
             data: expect.stringMatching('.*[ERR:001]*'),
           }),
-        }),
+        })
       );
     });
+  });
+});
+
+describe('CDK core constructs with non-PascalCase resources', () => {
+  beforeEach(() => {
+    const app = new cdk.App();
+    stack = new Stack(app);
+    cdk.Aspects.of(app).add(new CdkMentor());
+  });
+
+  /**
+   * Sample Cfn Template
+   *
+   * "BooksApiDeploymentStageprod0693B760": {
+   *   "Type": "AWS::ApiGateway::Stage",
+   *   ...
+   *   "Metadata": {
+   *     "aws:cdk:path": "Stack/BooksApi/DeploymentStage.prod/Resource"
+   *   }
+   * },
+   * "BooksApiANY0C4EABE3": {
+   *   "Type": "AWS::ApiGateway::Method",
+   *   ...
+   *   "Metadata": {
+   *     "aws:cdk:path": "Stack/BooksApi/ANY/Resource"
+   *   }
+   * },
+   * "BooksApiBooksbookid866FE5CE": {
+   *   "Type": "AWS::ApiGateway::Resource",
+   *   ...
+   *  "Metadata": {
+   *    "aws:cdk:path": "Stack/BooksApi/Books/{book_id}/Resource"
+   *  }
+   * },
+   *
+   */
+  test('Verify that API Gateway exists but does not raise an error', () => {
+    const api = new apigateway.RestApi(stack, 'BooksApi');
+    api.root.addMethod('ANY');
+    const books = api.root.addResource('Books');
+    books.addResource('{book_id}');
+    const template = Template.fromStack(stack);
+    template.resourceCountIs('AWS::ApiGateway::Stage', 1);
+    template.resourceCountIs('AWS::ApiGateway::Method', 1);
+    template.resourceCountIs('AWS::ApiGateway::Resource', 2);
+    const messages = SynthUtils.synthesize(stack).messages;
+    expect(messages).not.toContainEqual(
+      expect.objectContaining({
+        entry: expect.objectContaining({
+          data: expect.stringMatching('.*[ERR:001]*'),
+        }),
+      })
+    );
+  });
+
+  /**
+   * Sample Cfn Template
+   *
+   * "EventSourceMapping": {
+   *   "Type": "AWS::Lambda::EventSourceMapping",
+   *   ...
+   *   "Metadata": {
+   *     "aws:cdk:path": "Stack/LamDesFn/SqsEventSource:SandboxStackMyQueue3457E9E6/Resource"
+   *   }
+   * }
+   */
+  test('Verify that EventSourceMapping exists but does not raise an error', () => {
+    const fn = new lambda.Function(stack, 'LamDesFn', {
+      runtime: lambda.Runtime.NODEJS_18_X,
+      handler: 'index.handler',
+      code: cdk.aws_lambda.Code.fromInline('exports.handler = async () => {};'),
+    });
+    const queue = new sqs.Queue(stack, 'MyQueue');
+    fn.addEventSource(new cdk.aws_lambda_event_sources.SqsEventSource(queue));
+    const template = Template.fromStack(stack);
+    template.resourceCountIs('AWS::Lambda::EventSourceMapping', 1);
+    const messages = SynthUtils.synthesize(stack).messages;
+    expect(messages).not.toContainEqual(
+      expect.objectContaining({
+        entry: expect.objectContaining({
+          data: expect.stringMatching('.*[ERR:001]*'),
+        }),
+      })
+    );
+  });
+
+  /**
+   * Sample Cfn Template
+   *
+   * "HttpApiGETbooksGetBooksIntegration62C21291": {
+   *   "Type": "AWS::ApiGatewayV2::Integration",
+   *   ...
+   *   "Metadata": {
+   *     "aws:cdk:path": "Stack/HttpApi/GET--books/GetBooksIntegration/Resource"
+   *   }
+   * }
+   *
+   * "HttpApiGETbooksF1B941B8": {
+   *   "Type": "AWS::ApiGatewayV2::Route",
+   *   ...
+   *   "Metadata": {
+   *     "aws:cdk:path": "Stack/HttpApi/GET--books/Resource"
+   *   }
+   * }
+   * "BookStoreDefaultFnCustomRulePermissionn8NniGbw5Nkfrt94qGvLZ4YxlvUmRph2170mPuz9yXwBA47C678": {
+   *  "Type": "AWS::Lambda::Permission",
+   *  ...
+   *  "Metadata": {
+   *    "aws:cdk:path": "Stack/BookStoreDefaultFn/CustomRulePermissionn8NniGbw5Nkfrt94qGvLZ4YxlvUmRph2170mPuz9yXw="
+   *  }
+   * }
+   */
+  // This construct does not exist in the current version.
+  // This test will be implemented when cdk version 2.112.0 or later is used.
+  // See: https://github.com/aws/aws-cdk/releases/tag/v2.112.0
+
+  /**
+   * Sample Cfn Template
+   *
+   * "MyHostedConfigDeploymentA4784DFF660C3": {
+   *   "Type": "AWS::AppConfig::Deployment",
+   *   ...
+   *   "Metadata": {
+   *     "aws:cdk:path": "Stack/MyHostedConfig/DeploymentA4784"
+   *   }
+   * }
+   */
+  // This construct does not exist in the current version.
+  // This test will be implemented when cdk version 2.130.0 or later is used.
+  // See: https://github.com/aws/aws-cdk/releases/tag/v2.130.0
+
+  /**
+   * Sample Cfn Template
+   *
+   * "VpcPublicSubnet1EIPD7E02669": {
+   *   "Type": "AWS::EC2::EIP",
+   *   ...
+   *   "Metadata": {
+   *     "aws:cdk:path": "Stack/Vpc/PublicSubnet1/EIP"
+   *   }
+   * },
+   * "VpcIGWACA8CB6D": {
+   *   "Type": "AWS::EC2::InternetGateway",
+   *   ...
+   *   "Metadata": {
+   *     "aws:cdk:path": "Stack/Vpc/Vpc/IGW"
+   *   }
+   * },
+   * "VpcVPCGW5EA121D2": {
+   *   "Type": "AWS::EC2::VPCGatewayAttachment",
+   *   ...
+   *   "Metadata": {
+   *     "aws:cdk:path": "Stack/Vpc/Vpc/VPCGW"
+   *   }
+   * }
+   */
+  test('Verify that EIP/IGW/VPCGatewayAttachment exists but does not raise an error', () => {
+    new ec2.Vpc(stack, 'Vpc', {});
+    const template = Template.fromStack(stack);
+    template.resourceCountIs('AWS::EC2::EIP', 2);
+    template.resourceCountIs('AWS::EC2::InternetGateway', 1);
+    template.resourceCountIs('AWS::EC2::VPCGatewayAttachment', 1);
+    const messages = SynthUtils.synthesize(stack).messages;
+    expect(messages).not.toContainEqual(
+      expect.objectContaining({
+        entry: expect.objectContaining({
+          data: expect.stringMatching('.*[ERR:001]*'),
+        }),
+      })
+    );
+  });
+
+  /**
+   * Sample Cfn Template
+   *
+   * "AsgASGD1D7B4E2": {
+   *   "Type": "AWS::AutoScaling::AutoScalingGroup",
+   *   ...
+   *   "Metadata": {
+   *     "aws:cdk:path": "Stack/Asg/ASG"
+   *   }
+   * }
+   */
+  test('Verify that AutoScalingGroup exists but does not raise an error', () => {
+    const vpc = new ec2.Vpc(stack, 'Vpc', {});
+    new autoscaling.AutoScalingGroup(stack, 'Asg', {
+      vpc,
+      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
+      machineImage: ec2.MachineImage.latestAmazonLinux(),
+    });
+    const template = Template.fromStack(stack);
+    template.resourceCountIs('AWS::AutoScaling::AutoScalingGroup', 1);
+    const messages = SynthUtils.synthesize(stack).messages;
+    expect(messages).not.toContainEqual(
+      expect.objectContaining({
+        entry: expect.objectContaining({
+          data: expect.stringMatching('.*[ERR:001]*'),
+        }),
+      })
+    );
+  });
+
+  /**
+   * Sample Cfn Template
+   *
+   * "SecurityGroupName": {
+   *   Type": "AWS::EC2::SecurityGroupEgress",
+   *   "Properties": {
+   *     "Description": "to SecurityGroupA11500E8:80",
+   *   ...
+   *    "Metadata": {
+   *      "aws:cdk:path": "Stack/Sg/SecurityGroupId/to SecurityGroupA11500E8:80"
+   *   }
+   * }
+   */
+  test('Verify that SecurityGroupEgress exists but does not raise an error', () => {
+    const vpc = new ec2.Vpc(stack, 'Vpc', {});
+    const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+      vpc,
+      allowAllOutbound: false,
+    });
+    const securityGroup2 = new ec2.SecurityGroup(stack, 'SecurityGroup2', {
+      vpc,
+    });
+    securityGroup.addEgressRule(securityGroup2, ec2.Port.allTcp());
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::EC2::SecurityGroupEgress', {
+      Description: Match.stringLikeRegexp('to '),
+    });
+    const messages = SynthUtils.synthesize(stack).messages;
+    expect(messages).not.toContainEqual(
+      expect.objectContaining({
+        entry: expect.objectContaining({
+          data: expect.stringMatching('.*[ERR:001]*'),
+        }),
+      })
+    );
+  });
+
+  /**
+   * Sample Cfn Template
+   *
+   * "SecurityGroupName": {
+   *   Type": "AWS::EC2::SecurityGroupIngress",
+   *   "Properties": {
+   *     "Description": "from SecurityGroupA11500E8:80",
+   *   ...
+   *    "Metadata": {
+   *      "aws:cdk:path": "Stack/Sg/SecurityGroupId/from SecurityGroupA11500E8:80"
+   *   }
+   * }
+   */
+  test('Verify that SecurityGroupIngress exists but does not raise an error', () => {
+    const vpc = new ec2.Vpc(stack, 'Vpc', {});
+    const securityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', {
+      vpc,
+    });
+    const securityGroup2 = new ec2.SecurityGroup(stack, 'SecurityGroup2', {
+      vpc,
+    });
+    securityGroup.addIngressRule(securityGroup2, ec2.Port.allTcp());
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::EC2::SecurityGroupIngress', {
+      Description: Match.stringLikeRegexp('from '),
+    });
+    const messages = SynthUtils.synthesize(stack).messages;
+    expect(messages).not.toContainEqual(
+      expect.objectContaining({
+        entry: expect.objectContaining({
+          data: expect.stringMatching('.*[ERR:001]*'),
+        }),
+      })
+    );
+  });
+
+  /**
+   * Sample Cfn Template
+   *
+   * "awscdkawseksKubectlProviderNestedStackawscdkawseksKubectlProviderNestedStackResourceA7AEBA6B": {
+   *   "Type": "AWS::CloudFormation::Stack",
+   *   ...
+   *   "Metadata": {
+   *     "aws:cdk:path": "Stack/@aws-cdk--aws-eks.KubectlProvider.NestedStack/@aws-cdk--aws-eks.KubectlProvider.NestedStackResource",
+   *   }
+   * }
+   */
+  test('Verify that CloudFormation::Stack exists but does not raise an error', () => {
+    new eks.Cluster(stack, 'HelloEks', {
+      version: eks.KubernetesVersion.V1_24,
+      kubectlLayer: new KubectlV24Layer(stack, 'Kubectl'),
+    });
+    const template = Template.fromStack(stack);
+    template.resourceCountIs('AWS::CloudFormation::Stack', 2);
+    const messages = SynthUtils.synthesize(stack).messages;
+    expect(messages).not.toContainEqual(
+      expect.objectContaining({
+        entry: expect.objectContaining({
+          data: expect.stringMatching('.*[ERR:001]*'),
+        }),
+      })[0] // MEMO: EKS L2 construct includes two CloudFormation::Stack
+    );
+  });
+
+  /**
+   * Sample Cfn Template
+   *
+   * "Route53RedirectRedirectDistributionCFDistributionFD10977D": {
+   *   "Type": "AWS::CloudFront::Distribution",
+   *   ...
+   *   "Metadata": {
+   *     "aws:cdk:path": "Stack/Route53Redirect/RedirectDistribution/CFDistribution"
+   *   }
+   * }
+   */
+  test('Verify that CloudFront::Distribution exists but does not raise an error', () => {
+    new route53Patterns.HttpsRedirect(stack, 'Route53Redirect', {
+      recordNames: ['foo.example.com'],
+      targetDomain: 'bar.example.com',
+      zone: route53.HostedZone.fromHostedZoneAttributes(stack, 'Route53HostedZone2', {
+        hostedZoneId: 'ID',
+        zoneName: 'example.com',
+      }),
+    });
+    const template = Template.fromStack(stack);
+    template.resourceCountIs('AWS::CloudFront::Distribution', 1);
+    // MEMO: No error in case of CFDistribution
+    const messages = SynthUtils.synthesize(stack).messages;
+    expect(messages).not.toContainEqual(
+      expect.objectContaining({
+        entry: expect.objectContaining({
+          data: expect.stringMatching('.*[ERR:001]*'),
+        }),
+      })
+    );
+  });
+
+  /**
+   * Sample Cfn Template
+   *
+   * "TopichttpsfoobarcomE7064E32": {
+   *   "Type": "AWS::SNS::Subscription",
+   *   "Properties": {
+   *     "Endpoint": "https://foobar.com/",
+   *   ...
+   *   "Metadata": {
+   *     "aws:cdk:path": "Stack/Topic2/https:----foobar.com--/Resource"
+   *   }
+   * }
+   */
+  test('Verify that SNS::Subscription exists but does not raise an error', () => {
+    const topic = new sns.Topic(stack, 'Topic');
+    topic.addSubscription(new subs.UrlSubscription('https://foobar.com/'));
+    const template = Template.fromStack(stack);
+    template.resourceCountIs('AWS::SNS::Subscription', 1);
+    const messages = SynthUtils.synthesize(stack).messages;
+    expect(messages).not.toContainEqual(
+      expect.objectContaining({
+        entry: expect.objectContaining({
+          data: expect.stringMatching('.*[ERR:001]*'),
+        }),
+      })
+    );
+  });
+
+  /**
+   * Sample Cfn Template
+   *
+   * "PatternsServiceLBPublicListener4CEFDB78": {
+   *   Type": "AWS::ElasticLoadBalancingV2::Listener",
+   *   ...
+   *    "Metadata": {
+   *      "aws:cdk:path": "Stack/PatternsService/LB/PublicListener/Resource"
+   *   }
+   * },
+   * "PatternsServiceLBPublicListenerECSGroupCDF3FD59": {
+   *   Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+   *   ...
+   *    "Metadata": {
+   *      "aws:cdk:path": "Stack/PatternsService/LB/PublicListener/ECSGroup/Resource"
+   *   }
+   * }
+   */
+  test('Verify that ElasticLoadBalancingV2 exists but does not raise an error. Only when using EcsPatterns', () => {
+    const vpc = new ec2.Vpc(stack, 'Vpc', {});
+    const cluster = new ecs.Cluster(stack, 'Cluster', {
+      vpc,
+    });
+    cluster.addCapacity('DefaultAutoScalingGroupCapacity', {
+      instanceType: new ec2.InstanceType('t2.small'),
+      desiredCapacity: 3,
+    });
+    new ecsPatterns.ApplicationLoadBalancedEc2Service(stack, 'PatternsService', {
+      cluster,
+      memoryLimitMiB: 1024,
+      taskImageOptions: {
+        image: ecs.ContainerImage.fromRegistry('test'),
+        command: ['command'],
+        entryPoint: ['entry', 'point'],
+      },
+      desiredCount: 1,
+    });
+    const template = Template.fromStack(stack);
+    template.resourceCountIs('AWS::ElasticLoadBalancingV2::LoadBalancer', 1);
+    template.resourceCountIs('AWS::ElasticLoadBalancingV2::TargetGroup', 1);
+    // MEMO: No error in case of LB or ECSGroup
+    const messages = SynthUtils.synthesize(stack).messages;
+    expect(messages).not.toContainEqual(
+      expect.objectContaining({
+        entry: expect.objectContaining({
+          data: expect.stringMatching('.*[ERR:001]*'),
+        }),
+      })[0] // MEMO: Since ECS Patterns contains Nested Stacks internally, specify index 0
+    );
+  });
+
+  /**
+   * Sample Cfn Template
+   *
+   * "UserPoolsmsRole4EA729DD": {
+   *   "Type": "AWS::IAM::Role",
+   *   ...
+   *   "Metadata": {
+   *     "aws:cdk:path": "Stack/UserPool/ssmRole/Resource"
+   *   }
+   * }
+   */
+  test('Verify that `smsRole` exists but does not raise an error', () => {
+    new cognito.UserPool(stack, 'UserPool', {
+      userPoolName: 'test-user-pool',
+      mfa: cdk.aws_cognito.Mfa.OPTIONAL,
+    });
+    const template = Template.fromStack(stack);
+    // MEMO: Verify smsRole using fixed policy name 'sns-publish' as it only exists in Metadata
+    template.hasResourceProperties('AWS::IAM::Role', {
+      Policies: [
+        {
+          PolicyName: 'sns-publish',
+        },
+      ],
+    });
+    const messages = SynthUtils.synthesize(stack).messages;
+    expect(messages).not.toContainEqual(
+      expect.objectContaining({
+        entry: expect.objectContaining({
+          data: expect.stringMatching('.*[ERR:001]*'),
+        }),
+      })
+    );
   });
 });
 
@@ -76,7 +543,7 @@ describe("Avoid 'Stack' or 'Construct' in Construct names", () => {
           entry: expect.objectContaining({
             data: expect.stringMatching('.*[WARN:001]*'),
           }),
-        }),
+        })
       );
     });
   });
@@ -98,7 +565,7 @@ describe('Detecte strong cross-stack references ', () => {
       super(scope, id, props);
       const testTopic = props.testTopic;
       const queue = new sqs.Queue(this, 'TestQueue');
-      testTopic.addSubscription(new SqsSubscription(queue));
+      testTopic.addSubscription(new snsSubscriptions.SqsSubscription(queue));
     }
   }
   test('Issue a warning when using strong cross-stack references', () => {
@@ -114,7 +581,7 @@ describe('Detecte strong cross-stack references ', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[WARN:003]*'),
         }),
-      }),
+      })
     );
   });
 
@@ -131,7 +598,7 @@ describe('Detecte strong cross-stack references ', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[WARN:003]*'),
         }),
-      }),
+      })
     );
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,24 +1,24 @@
 import { SynthUtils } from '@aws-cdk/assert';
 
+import { KubectlV24Layer } from '@aws-cdk/lambda-layer-kubectl-v24';
 import * as cdk from 'aws-cdk-lib';
 
 import { Stack } from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
-import { Construct } from 'constructs';
-import * as sns from 'aws-cdk-lib/aws-sns';
-import * as sqs from 'aws-cdk-lib/aws-sqs';
 import * as apigateway from 'aws-cdk-lib/aws-apigateway';
 import * as autoscaling from 'aws-cdk-lib/aws-autoscaling';
 import * as cognito from 'aws-cdk-lib/aws-cognito';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as ecsPatterns from 'aws-cdk-lib/aws-ecs-patterns';
 import * as eks from 'aws-cdk-lib/aws-eks';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import * as route53Patterns from 'aws-cdk-lib/aws-route53-patterns';
+import * as sns from 'aws-cdk-lib/aws-sns';
 import * as snsSubscriptions from 'aws-cdk-lib/aws-sns-subscriptions';
-import * as ec2 from 'aws-cdk-lib/aws-ec2';
-import { KubectlV24Layer } from '@aws-cdk/lambda-layer-kubectl-v24';
+import * as sqs from 'aws-cdk-lib/aws-sqs';
+import { Construct } from 'constructs';
 
 // MEMO: The following modules are not available in the current CDK version
 // import * as appconfig from '@aws-cdk/aws-appconfig';
@@ -43,7 +43,7 @@ describe('PascalCase Construct ID Check', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })
+      }),
     );
   });
   describe.each`
@@ -67,7 +67,7 @@ describe('PascalCase Construct ID Check', () => {
           entry: expect.objectContaining({
             data: expect.stringMatching('.*[ERR:001]*'),
           }),
-        })
+        }),
       );
     });
   });
@@ -121,7 +121,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })
+      }),
     );
   });
 
@@ -152,7 +152,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })
+      }),
     );
   });
 
@@ -238,7 +238,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })
+      }),
     );
   });
 
@@ -268,7 +268,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })
+      }),
     );
   });
 
@@ -305,7 +305,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })
+      }),
     );
   });
 
@@ -341,7 +341,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })
+      }),
     );
   });
 
@@ -369,7 +369,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })[0] // MEMO: EKS L2 construct includes two CloudFormation::Stack
+      })[0], // MEMO: EKS L2 construct includes two CloudFormation::Stack
     );
   });
 
@@ -402,7 +402,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })
+      }),
     );
   });
 
@@ -430,7 +430,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })
+      }),
     );
   });
 
@@ -481,7 +481,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })[0] // MEMO: Since ECS Patterns contains Nested Stacks internally, specify index 0
+      })[0], // MEMO: Since ECS Patterns contains Nested Stacks internally, specify index 0
     );
   });
 
@@ -516,7 +516,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })
+      }),
     );
   });
 });
@@ -542,7 +542,7 @@ describe("Avoid 'Stack' or 'Construct' in Construct names", () => {
           entry: expect.objectContaining({
             data: expect.stringMatching('.*[WARN:001]*'),
           }),
-        })
+        }),
       );
     });
   });
@@ -580,7 +580,7 @@ describe('Detecte strong cross-stack references ', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[WARN:003]*'),
         }),
-      })
+      }),
     );
   });
 
@@ -597,7 +597,7 @@ describe('Detecte strong cross-stack references ', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[WARN:003]*'),
         }),
-      })
+      }),
     );
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -17,7 +17,6 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import * as route53Patterns from 'aws-cdk-lib/aws-route53-patterns';
 import * as snsSubscriptions from 'aws-cdk-lib/aws-sns-subscriptions';
-import * as subs from 'aws-cdk-lib/aws-sns-subscriptions';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import { KubectlV24Layer } from '@aws-cdk/lambda-layer-kubectl-v24';
 
@@ -422,7 +421,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
    */
   test('Verify that SNS::Subscription exists but does not raise an error', () => {
     const topic = new sns.Topic(stack, 'Topic');
-    topic.addSubscription(new subs.UrlSubscription('https://foobar.com/'));
+    topic.addSubscription(new snsSubscriptions.UrlSubscription('https://foobar.com/'));
     const template = Template.fromStack(stack);
     template.resourceCountIs('AWS::SNS::Subscription', 1);
     const messages = SynthUtils.synthesize(stack).messages;

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,6 +52,11 @@
     string-width "^4.2.3"
     table "^6.8.1"
 
+"@aws-cdk/lambda-layer-kubectl-v24@^2.0.242":
+  version "2.0.242"
+  resolved "https://registry.npmjs.org/@aws-cdk/lambda-layer-kubectl-v24/-/lambda-layer-kubectl-v24-2.0.242.tgz"
+  integrity sha512-7/wIOo685tmrEe4hh6zqDELhBZh5OQGf3Hd2FU2Vnwy2ZubW8qTmEw5gqJCsCrGKeYDoa1BcVhDRZ/nzjkaqyA==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.25.9", "@babel/code-frame@^7.26.0":
   version "7.26.2"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz"
@@ -1221,7 +1226,7 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-aws-cdk-lib@^2.68.0, aws-cdk-lib@2.68.0:
+aws-cdk-lib@^2.28.0, aws-cdk-lib@^2.68.0, aws-cdk-lib@2.68.0:
   version "2.68.0"
   resolved "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.68.0.tgz"
   integrity sha512-roN3xwzv/GleGG3CaJrf+thdzr9WBzJU4LotumEOs+0cGfeXSta8Pm/cGAeY4kplr5r10QWUovH0fv/bi6Vrbw==
@@ -1588,7 +1593,7 @@ concat-stream@^2.0.0:
     readable-stream "^3.0.2"
     typedarray "^0.0.6"
 
-constructs@^10.0.0, constructs@10.0.5:
+constructs@^10.0.0, constructs@^10.0.5, constructs@10.0.5:
   version "10.0.5"
   resolved "https://registry.npmjs.org/constructs/-/constructs-10.0.5.tgz"
   integrity sha512-IwOwekzrASFC3qt4ozCtV09rteAIAesuCGsW0p+uBfqHd2XcvA5CXqJjgf4eUqm6g8e/noXlVCMDWwC8GaLtrg==
@@ -2504,6 +2509,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@^2.3.2:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2510,11 +2510,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^2.3.2:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"


### PR DESCRIPTION
Fixes #4 

## Describe the feature

Implement exclusion rules by checking Construct IDs and AWS Resource Types. Exclude when:

- Matching specific AWS resources
- Contains specific prefixes (example: Custom::)
- Matching specific ID names for particular AWS resources (example: ecs-patterns)