### PR TITLE
fix: exclude AWS::Lambda::Permission as its ConstructId contains "Stack"

### DIFF
--- a/src/excluded-resource-types.ts
+++ b/src/excluded-resource-types.ts
@@ -44,3 +44,5 @@ export const EXCLUDED_RESOURCE_AND_NAME_PATTERNS: RESOURCE_AND_NAME_PATTERN[] = 
     namePattern: 'smsRole',
   },
 ];
+
+export const CONTAINING_STACK_NAME_RESOURCES = new Set(['AWS::Lambda::Permission']);

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export class CdkMentor implements cdk.IAspect {
           !EXCLUDED_RESOURCE_TYPES.has(node.cfnResourceType) &&
           !EXCLUDED_PREFIX_NAMES.some((prefix) => constructId.startsWith(prefix)) &&
           !EXCLUDED_RESOURCE_AND_NAME_PATTERNS.some(
-            (rule) => node.cfnResourceType === rule.resourceType && constructId.includes(rule.namePattern)
+            (rule) => node.cfnResourceType === rule.resourceType && constructId.includes(rule.namePattern),
           )
         ) {
           cdk.Annotations.of(node).addError(`[ERR:001]: Construct ID "${constructId}"should be defined in PascalCase.`);
@@ -41,7 +41,7 @@ export class CdkMentor implements cdk.IAspect {
         // If it is not a CrossStack reference, immediately WARN
         if (stackDependencies && Object.keys(stackDependencies).length === 0) {
           cdk.Annotations.of(node).addWarning(
-            `[WARN:001]: Construct ID names should NOT include the word "Stack" "${constructId}". The Stack concept from CDK is reflected in the resource names.`
+            `[WARN:001]: Construct ID names should NOT include the word "Stack" "${constructId}". The Stack concept from CDK is reflected in the resource names.`,
           );
         }
         // Exclude if it is a CrossStack reference and the referenced stack name is included.
@@ -52,14 +52,14 @@ export class CdkMentor implements cdk.IAspect {
           !constructId.includes(this.getJsonRootKey(stackDependencies))
         ) {
           cdk.Annotations.of(node).addWarning(
-            `[WARN:001]: Construct ID names should NOT include the word "Stack" "${constructId}". The Stack concept from CDK is reflected in the resource names.`
+            `[WARN:001]: Construct ID names should NOT include the word "Stack" "${constructId}". The Stack concept from CDK is reflected in the resource names.`,
           );
         }
       }
 
       if (constructId && constructId.includes('Construct')) {
         cdk.Annotations.of(node).addWarning(
-          `[WARN:002]: Construct ID names should NOT include the word "Construct" "${constructId}". The Construct concept from CDK is reflected in the resource names.`
+          `[WARN:002]: Construct ID names should NOT include the word "Construct" "${constructId}". The Construct concept from CDK is reflected in the resource names.`,
         );
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
   EXCLUDED_PREFIX_NAMES,
   EXCLUDED_RESOURCE_TYPES,
   EXCLUDED_RESOURCE_AND_NAME_PATTERNS,
+  CONTAINING_STACK_NAME_RESOURCES,
 } from './excluded-resource-types';
 
 export class CdkMentor implements cdk.IAspect {
@@ -22,7 +23,7 @@ export class CdkMentor implements cdk.IAspect {
           !EXCLUDED_RESOURCE_TYPES.has(node.cfnResourceType) &&
           !EXCLUDED_PREFIX_NAMES.some((prefix) => constructId.startsWith(prefix)) &&
           !EXCLUDED_RESOURCE_AND_NAME_PATTERNS.some(
-            (rule) => node.cfnResourceType === rule.resourceType && constructId.includes(rule.namePattern),
+            (rule) => node.cfnResourceType === rule.resourceType && constructId.includes(rule.namePattern)
           )
         ) {
           cdk.Annotations.of(node).addError(`[ERR:001]: Construct ID "${constructId}"should be defined in PascalCase.`);
@@ -32,7 +33,7 @@ export class CdkMentor implements cdk.IAspect {
       /**
        * Do not include the words "Stack" or "Construct" in the Construct ID names
        */
-      if (constructId && constructId.includes('Stack')) {
+      if (constructId && constructId.includes('Stack') && !CONTAINING_STACK_NAME_RESOURCES.has(node.cfnResourceType)) {
         // MEMO: Exclude if it is a CrossStack reference
         // If the stack has CrossStack references and the resource is referencing another stack, exclude it
         const stack = cdk.Stack.of(node);
@@ -40,7 +41,7 @@ export class CdkMentor implements cdk.IAspect {
         // If it is not a CrossStack reference, immediately WARN
         if (stackDependencies && Object.keys(stackDependencies).length === 0) {
           cdk.Annotations.of(node).addWarning(
-            `[WARN:001]: Construct ID names should NOT include the word "Stack" "${constructId}". The Stack concept from CDK is reflected in the resource names.`,
+            `[WARN:001]: Construct ID names should NOT include the word "Stack" "${constructId}". The Stack concept from CDK is reflected in the resource names.`
           );
         }
         // Exclude if it is a CrossStack reference and the referenced stack name is included.
@@ -51,14 +52,14 @@ export class CdkMentor implements cdk.IAspect {
           !constructId.includes(this.getJsonRootKey(stackDependencies))
         ) {
           cdk.Annotations.of(node).addWarning(
-            `[WARN:001]: Construct ID names should NOT include the word "Stack" "${constructId}". The Stack concept from CDK is reflected in the resource names.`,
+            `[WARN:001]: Construct ID names should NOT include the word "Stack" "${constructId}". The Stack concept from CDK is reflected in the resource names.`
           );
         }
       }
 
       if (constructId && constructId.includes('Construct')) {
         cdk.Annotations.of(node).addWarning(
-          `[WARN:002]: Construct ID names should NOT include the word "Construct" "${constructId}". The Construct concept from CDK is reflected in the resource names.`,
+          `[WARN:002]: Construct ID names should NOT include the word "Construct" "${constructId}". The Construct concept from CDK is reflected in the resource names.`
         );
       }
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -43,7 +43,7 @@ describe('PascalCase Construct ID Check', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })
+      }),
     );
   });
   describe.each`
@@ -67,7 +67,7 @@ describe('PascalCase Construct ID Check', () => {
           entry: expect.objectContaining({
             data: expect.stringMatching('.*[ERR:001]*'),
           }),
-        })
+        }),
       );
     });
   });
@@ -121,7 +121,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })
+      }),
     );
   });
 
@@ -152,7 +152,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })
+      }),
     );
   });
 
@@ -238,7 +238,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })
+      }),
     );
   });
 
@@ -268,7 +268,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })
+      }),
     );
   });
 
@@ -305,7 +305,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })
+      }),
     );
   });
 
@@ -341,7 +341,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })
+      }),
     );
   });
 
@@ -369,7 +369,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })[0] // MEMO: EKS L2 construct includes two CloudFormation::Stack
+      })[0], // MEMO: EKS L2 construct includes two CloudFormation::Stack
     );
   });
 
@@ -402,7 +402,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })
+      }),
     );
   });
 
@@ -430,7 +430,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })
+      }),
     );
   });
 
@@ -481,7 +481,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })[0] // MEMO: Since ECS Patterns contains Nested Stacks internally, specify index 0
+      })[0], // MEMO: Since ECS Patterns contains Nested Stacks internally, specify index 0
     );
   });
 
@@ -516,7 +516,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })
+      }),
     );
   });
 });
@@ -542,7 +542,7 @@ describe("Avoid 'Stack' or 'Construct' in Construct names", () => {
           entry: expect.objectContaining({
             data: expect.stringMatching('.*[WARN:001]*'),
           }),
-        })
+        }),
       );
     });
   });
@@ -577,7 +577,7 @@ describe("Avoid 'Stack' or 'Construct' in Construct names", () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[WARN:001]*'),
         }),
-      })
+      }),
     );
   });
 });
@@ -614,7 +614,7 @@ describe('Detecte strong cross-stack references ', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[WARN:003]*'),
         }),
-      })
+      }),
     );
   });
 
@@ -631,7 +631,7 @@ describe('Detecte strong cross-stack references ', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[WARN:003]*'),
         }),
-      })
+      }),
     );
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -43,7 +43,7 @@ describe('PascalCase Construct ID Check', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      }),
+      })
     );
   });
   describe.each`
@@ -67,7 +67,7 @@ describe('PascalCase Construct ID Check', () => {
           entry: expect.objectContaining({
             data: expect.stringMatching('.*[ERR:001]*'),
           }),
-        }),
+        })
       );
     });
   });
@@ -121,7 +121,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      }),
+      })
     );
   });
 
@@ -152,7 +152,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      }),
+      })
     );
   });
 
@@ -238,7 +238,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      }),
+      })
     );
   });
 
@@ -268,7 +268,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      }),
+      })
     );
   });
 
@@ -305,7 +305,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      }),
+      })
     );
   });
 
@@ -341,7 +341,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      }),
+      })
     );
   });
 
@@ -369,7 +369,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })[0], // MEMO: EKS L2 construct includes two CloudFormation::Stack
+      })[0] // MEMO: EKS L2 construct includes two CloudFormation::Stack
     );
   });
 
@@ -402,7 +402,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      }),
+      })
     );
   });
 
@@ -430,7 +430,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      }),
+      })
     );
   });
 
@@ -481,7 +481,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      })[0], // MEMO: Since ECS Patterns contains Nested Stacks internally, specify index 0
+      })[0] // MEMO: Since ECS Patterns contains Nested Stacks internally, specify index 0
     );
   });
 
@@ -516,7 +516,7 @@ describe('CDK core constructs with non-PascalCase resources', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[ERR:001]*'),
         }),
-      }),
+      })
     );
   });
 });
@@ -542,9 +542,43 @@ describe("Avoid 'Stack' or 'Construct' in Construct names", () => {
           entry: expect.objectContaining({
             data: expect.stringMatching('.*[WARN:001]*'),
           }),
-        }),
+        })
       );
     });
+  });
+
+  /**
+   * Sample Cfn Template
+   * "BooksApiGETApiPermissionTestStackBooksApiA2CED8D6GET911FB15C": {
+   *   "Type": "AWS::Lambda::Permission",
+   *   ...
+   *   "Metadata": {
+   *     "aws:cdk:path": "TestStack/BooksApi/Default/GET/ApiPermission.TestStackBooksApiA2CED8D6.GET.."
+   *   }
+   * }
+   */
+  test('No warning when NOT using Stack or Construct in Construct names', () => {
+    const app = new cdk.App();
+    stack = new Stack(app, 'Stack', {});
+    cdk.Aspects.of(app).add(new CdkMentor());
+
+    const api = new apigateway.RestApi(stack, 'BooksApi');
+    const fn = new lambda.Function(stack, 'LamDesFn', {
+      runtime: lambda.Runtime.NODEJS_18_X,
+      handler: 'index.handler',
+      code: cdk.aws_lambda.Code.fromInline('exports.handler = async () => {};'),
+    });
+    api.root.addMethod('GET', new apigateway.LambdaIntegration(fn));
+
+    const messages = SynthUtils.synthesize(stack).messages;
+
+    expect(messages).not.toContainEqual(
+      expect.objectContaining({
+        entry: expect.objectContaining({
+          data: expect.stringMatching('.*[WARN:001]*'),
+        }),
+      })
+    );
   });
 });
 
@@ -580,7 +614,7 @@ describe('Detecte strong cross-stack references ', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[WARN:003]*'),
         }),
-      }),
+      })
     );
   });
 
@@ -597,7 +631,7 @@ describe('Detecte strong cross-stack references ', () => {
         entry: expect.objectContaining({
           data: expect.stringMatching('.*[WARN:003]*'),
         }),
-      }),
+      })
     );
   });
 });


### PR DESCRIPTION
## Overview

Exclude AWS::Lambda::Permission which always generates Node.path containing stack name.

```json
{
 "BooksApiGETApiPermissionTestStackBooksApiA2CED8D6GET911FB15C": {
   "Type": "AWS::Lambda::Permission",
   "Metadata": {
     "aws:cdk:path": "TestStack/BooksApi/Default/GET/ApiPermission.TestStackBooksApiA2CED8D6.GET.."
   }
 }
}
```